### PR TITLE
Run it in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ package-lock.json
 .vscode*
 
 .env
+digest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10
+
+ARG PROJECT
+WORKDIR /opt/${PROJECT}
+
+RUN apt-get update && apt-get install -y make
+
+COPY ./requirements.txt ${WORKDIR}
+RUN python -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PROJECT = mastodon_digest
+ID = something/${PROJECT}
+
+build:
+	docker build \
+		--build-arg PROJECT=${PROJECT} \
+		--tag ${ID} .
+
+run:
+	docker run \
+		--name ${PROJECT} \
+		--hostname ${PROJECT} \
+		--volume $(shell pwd):/opt/${PROJECT} \
+		--interactive \
+		--tty \
+		--rm \
+		${ID} \
+		bash
+
+exec:
+	docker exec \
+		--interactive \
+		--tty \
+		${PROJECT} \
+		bash

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ exec:
 		--tty \
 		${PROJECT} \
 		bash
+
+digest:
+	python run.py

--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import webbrowser
 from typing import TYPE_CHECKING
+from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 from mastodon import Mastodon
@@ -24,11 +25,8 @@ def render_and_open_digest(context: dict) -> None:
     template = environment.get_template("digest.html.jinja")
     output_html = template.render(context)
 
-    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".html") as out_file:
-        final_url = f"file://{out_file.name}"
-        out_file.write(output_html)
+    Path("digest.html").write_text(output_html)
 
-    webbrowser.open(final_url)
 
 
 def run(


### PR DESCRIPTION
I like to run these kinds of things in Docker, to avoid installing a million versions of a million dependencies all over my laptop. To build and run it:

```
make build
make run
```

From that shell on the container, run it:

```
make digest
```

It outputs to a known path, `./digest.html`, so from a different terminal, still in this directory, do

```
open digest.html
```

(at least on a Mac)