### PR TITLE
Added viewport meta tag and page title

### DIFF
--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mastodon Digest</title>
     {% include "style.html.jinja" %}
     <script src="https://static-cdn.mastodon.social/embed.js" async="async"></script>
 </head>

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     {% include "style.html.jinja" %}
     <script src="https://static-cdn.mastodon.social/embed.js" async="async"></script>
 </head>


### PR DESCRIPTION
When opening the output file on a mobile device, having the viewport tag set improves the scale of the page and reduces the need for zooming and scrolling.