### PR TITLE
Add support for specifying a timeline source for the digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ options:
   -n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}
                         The number of hours to include in the Mastodon Digest (default: 12)
   -s {ExtendedSimple,ExtendedSimpleWeighted,Simple,SimpleWeighted}
-                        Which post scoring criteria to use. Simple scorers take a geometric mean of boosts and favs. Extended
-                        scorers include reply counts in the geometric mean. Weighted scorers multiply the score by an inverse
-                        sqaure root of the author's followers, to reduce the influence of large accounts. (default:
-                        SimpleWeighted)
+                        Which post scoring criteria to use. Simple scorers take a geometric
+                        mean of boosts and favs. Extended scorers include reply counts in
+                        the geometric mean. Weighted scorers multiply the score by an
+                        inverse square root of the author's followers, to reduce the
+                        influence of large accounts. (default: SimpleWeighted)
   -t {lax,normal,strict}
                         Which post threshold criteria to use. lax = 90th percentile, normal = 95th percentile, strict = 98th
                         percentile (default: normal)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also pass [command arguments](#command-arguments):
 
 ```sh
 make run FLAGS="-n 8 -s Simple -t lax"
-``` 
+```
 
 ### Local
 
@@ -72,25 +72,24 @@ python run.py -h
 ```
 
 ```
-usage: mastodon_digest [-h]
-                       [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}]
-                       [-s {ExtendedSimple,ExtendedSimpleWeighted,Simple,SimpleWeighted}]
-                       [-t {lax,normal,strict}]
+usage: mastodon_digest [-h] [-f TIMELINE] [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}]
+                       [-s {ExtendedSimple,ExtendedSimpleWeighted,Simple,SimpleWeighted}] [-t {lax,normal,strict}]
                        [-o OUTPUT_DIR]
 
 options:
   -h, --help            show this help message and exit
+  -f TIMELINE           The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'. Defaults
+                        to 'home' (default: home)
   -n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}
                         The number of hours to include in the Mastodon Digest (default: 12)
   -s {ExtendedSimple,ExtendedSimpleWeighted,Simple,SimpleWeighted}
-                        Which post scoring criteria to use. Simple scorers take a geometric
-                        mean of boosts and favs. Extended scorers include reply counts in
-                        the geometric mean. Weighted scorers multiply the score by an
-                        inverse sqaure root of the author's followers, to reduce the
-                        influence of large accounts. (default: SimpleWeighted)
+                        Which post scoring criteria to use. Simple scorers take a geometric mean of boosts and favs. Extended
+                        scorers include reply counts in the geometric mean. Weighted scorers multiply the score by an inverse
+                        sqaure root of the author's followers, to reduce the influence of large accounts. (default:
+                        SimpleWeighted)
   -t {lax,normal,strict}
-                        Which post threshold criteria to use. lax = 90th percentile, normal
-                        = 95th percentile, strict = 98th percentile (default: normal)
+                        Which post threshold criteria to use. lax = 90th percentile, normal = 95th percentile, strict = 98th
+                        percentile (default: normal)
   -o OUTPUT_DIR         Output directory for the rendered digest (default: ./render/)
 ```
 
@@ -101,16 +100,22 @@ make run FLAGS="-n 8 -s Simple -t lax"
 ```
 
 #### Algorithm Options
+ * `-f` : Timeline feed to source from. **home** is the default.
+    - `home` : Your home timeline.
+    - `local` : The local timeline for your instance; all the posts from users in an instance. This is more useful on small/medium-sized instances. Consider using a much smaller value for `-n` to limit the number of posts analysed.
+    - `federated` : The federated public timeline on your instance; all posts that your instance has seen. This is useful for discovering posts on very small or personal instances.
+    - `hashtag:HashTagName` : The timeline for the specified #hashtag. (Do not include the `#` in the name.)
+    - `list:3` : A list timeline. Lists are given numeric IDs (as in their URL, e.g. `https://example.social/lists/2`), which you must use for input here, not the list name.
  * `-n` : Number of hours to look back when building your digest. This can be an integer from 1 to 24. Defaults to **12**. I've found that 12 works well in the morning and 8 works well in the evening.
  * `-s` : Scoring method to use. **SimpleWeighted** is the default.
-   - `Simple` : Each post is scored with a modified [geometric mean](https://en.wikipedia.org/wiki/Geometric_mean) of its number of boosts and its number of favorites.
-   - `SimpleWeighted` : The same as `Simple`, but every score is multiplied by the inverse of the square root of the author's follower count. Therefore, authors with very large audiences will need to meet higher boost and favorite numbers. **This is the default scorer**.
-   - `ExtendedSimple` : Each post is scored with a modified [geometric mean](https://en.wikipedia.org/wiki/Geometric_mean) of its number of boosts, its number of favorites, and its number of replies.
-   - `ExtendedSimpleWeighted` : The same as `ExtendedSimple`, but every score is multiplied by the inverse of the square root of the author's follower count. Therefore, authors with very large audiences will need to meet higher boost, favorite, and reply numbers.
+    - `Simple` : Each post is scored with a modified [geometric mean](https://en.wikipedia.org/wiki/Geometric_mean) of its number of boosts and its number of favorites.
+    - `SimpleWeighted` : The same as `Simple`, but every score is multiplied by the inverse of the square root of the author's follower count. Therefore, authors with very large audiences will need to meet higher boost and favorite numbers. **This is the default scorer**.
+    - `ExtendedSimple` : Each post is scored with a modified [geometric mean](https://en.wikipedia.org/wiki/Geometric_mean) of its number of boosts, its number of favorites, and its number of replies.
+    - `ExtendedSimpleWeighted` : The same as `ExtendedSimple`, but every score is multiplied by the inverse of the square root of the author's follower count. Therefore, authors with very large audiences will need to meet higher boost, favorite, and reply numbers.
 * `-t` : Threshold for scores to include. **normal** is the default
-  - `lax` : Posts must achieve a score within the 90th percentile.
-  - `normal` : Posts must achieve a score within the 95th percentile. **This is the default threshold**.
-  - `strict` : Posts must achive a score within the 98th percentile.
+    - `lax` : Posts must achieve a score within the 90th percentile.
+    - `normal` : Posts must achieve a score within the 95th percentile. **This is the default threshold**.
+    - `strict` : Posts must achive a score within the 98th percentile.
 
 I'm still experimenting with these, so it's possible that I change the defaults in the future.
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ usage: mastodon_digest [-h] [-f TIMELINE] [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,
 
 options:
   -h, --help            show this help message and exit
-  -f TIMELINE           The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'. Defaults
-                        to 'home' (default: home)
+  -f TIMELINE           The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'. (default: home)
   -n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}
                         The number of hours to include in the Mastodon Digest (default: 12)
   -s {ExtendedSimple,ExtendedSimpleWeighted,Simple,SimpleWeighted}

--- a/api.py
+++ b/api.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def fetch_posts_and_boosts(
     hours: int, mastodon_client: Mastodon, mastodon_username: str, timeline: str
 ) -> tuple[list[ScoredPost], list[ScoredPost]]:
-    """Fetches posts form the home timeline that the account hasn't interacted with"""
+    """Fetches posts from the home timeline that the account hasn't interacted with"""
 
     TIMELINE_LIMIT = 1000
 

--- a/api.py
+++ b/api.py
@@ -32,14 +32,17 @@ def fetch_posts_and_boosts(
     #
     # We default to 'home' if the name is unrecognized
     if ":" in timeline:
-        timelineType, timelineName = timeline.split(":", 1)
+        timelineType, timelineId = timeline.lower().split(":", 1)
     else:
-        timelineType = timeline
+        timelineType = timeline.lower()
 
     if timelineType == "hashtag":
-        response = mastodon_client.timeline_hashtag(timelineName, min_id=start)
+        response = mastodon_client.timeline_hashtag(timelineId, min_id=start)
     elif timelineType == "list":
-        response = mastodon_client.timeline_list(timelineName, min_id=start)
+        if not timelineId.isnumeric():
+            raise TypeError('Cannot load list timeline: ID must be numeric, as in: https://example.social/lists/4')
+
+        response = mastodon_client.timeline_list(timelineId, min_id=start)
     elif timelineType == "federated":
         response = mastodon_client.timeline_public(min_id=start)
     elif timelineType == "local":

--- a/api.py
+++ b/api.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def fetch_posts_and_boosts(
-    hours: int, mastodon_client: Mastodon, mastodon_username: str
+    hours: int, mastodon_client: Mastodon, mastodon_username: str, timeline: str
 ) -> tuple[list[ScoredPost], list[ScoredPost]]:
     """Fetches posts form the home timeline that the account hasn't interacted with"""
 
@@ -27,8 +27,27 @@ def fetch_posts_and_boosts(
     seen_post_urls = set()
     total_posts_seen = 0
 
-    # Iterate over our home timeline until we run out of posts or we hit the limit
-    response = mastodon_client.timeline(min_id=start)
+    # If timeline name is specified as hashtag:tagName or list:list-name, look-up with those names,
+    # else accept 'federated' and 'local' to process from the server public and local timelines.
+    #
+    # We default to 'home' if the name is unrecognized
+    if ":" in timeline:
+        timelineType, timelineName = timeline.split(":", 1)
+    else:
+        timelineType = timeline
+
+    if timelineType == "hashtag":
+        response = mastodon_client.timeline_hashtag(timelineName, min_id=start)
+    elif timelineType == "list":
+        response = mastodon_client.timeline_list(timelineName, min_id=start)
+    elif timelineType == "federated":
+        response = mastodon_client.timeline_public(min_id=start)
+    elif timelineType == "local":
+        response = mastodon_client.timeline_local(min_id=start)
+    else:
+        response = mastodon_client.timeline(min_id=start)
+
+    # Iterate over our timeline until we run out of posts or we hit the limit
     while response and total_posts_seen < TIMELINE_LIMIT:
 
         # Apply our server-side filters

--- a/api.py
+++ b/api.py
@@ -14,7 +14,7 @@ def fetch_posts_and_boosts(
 ) -> tuple[list[ScoredPost], list[ScoredPost]]:
     """Fetches posts from the home timeline that the account hasn't interacted with"""
 
-    TIMELINE_LIMIT = 1000
+    TIMELINE_LIMIT = 1000  # Should this be documented? Configurable?
 
     # First, get our filters
     filters = mastodon_client.filters()

--- a/api.py
+++ b/api.py
@@ -40,7 +40,7 @@ def fetch_posts_and_boosts(
         response = mastodon_client.timeline_hashtag(timelineId, min_id=start)
     elif timelineType == "list":
         if not timelineId.isnumeric():
-            raise TypeError('Cannot load list timeline: ID must be numeric, as in: https://example.social/lists/4')
+            raise TypeError('Cannot load list timeline: ID must be numeric, e.g.: https://example.social/lists/4 would be list:4')
 
         response = mastodon_client.timeline_list(timelineId, min_id=start)
     elif timelineType == "federated":

--- a/run.py
+++ b/run.py
@@ -74,7 +74,6 @@ def run(
             output_dir=output_dir,
         )
 
-
 if __name__ == "__main__":
     scorers = get_scorers()
     thresholds = get_thresholds()

--- a/run.py
+++ b/run.py
@@ -102,10 +102,10 @@ if __name__ == "__main__":
         choices=list(scorers.keys()),
         default="SimpleWeighted",
         dest="scorer",
-        help="""Which post scoring criteria to use.  
-            Simple scorers take a geometric mean of boosts and favs. 
-            Extended scorers include reply counts in the geometric mean. 
-            Weighted scorers multiply the score by an inverse square root 
+        help="""Which post scoring criteria to use.
+            Simple scorers take a geometric mean of boosts and favs.
+            Extended scorers include reply counts in the geometric mean.
+            Weighted scorers multiply the score by an inverse square root
             of the author's followers, to reduce the influence of large accounts.
         """,
     )
@@ -144,6 +144,14 @@ if __name__ == "__main__":
     if not mastodon_username:
         sys.exit("Missing environment variable: MASTODON_USERNAME")
 
+    # Loosely validate the timeline argument, so that if a completely unexpected string is entered,
+    # we explicitly reset to 'Home', which makes the rendered output cleaner.
+    timeline = args.timeline.strip().lower()
+    validTimelineTypes = ['home', 'local', 'federated', 'hashtag', 'list']
+    timelineType, *_ = timeline.split(":", 1)
+    if not timelineType in validTimelineTypes:
+        timeline = 'home'
+
     run(
         args.hours,
         scorers[args.scorer](),
@@ -151,6 +159,6 @@ if __name__ == "__main__":
         mastodon_token,
         format_base_url(mastodon_base_url),
         mastodon_username,
-        args.timeline.strip(),
+        timeline,
         output_dir,
     )

--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ def run(
     )
 
     # 1. Fetch all the posts and boosts from our home timeline that we haven't interacted with
-    posts, boosts = fetch_posts_and_boosts(hours, mst, mastodon_username, timeline)
+    posts, boosts = fetch_posts_and_boosts(hours, mst, mastodon_username, timeline.lower())
 
     # 2. Score them, and return those that meet our threshold
     threshold_posts = threshold.posts_meeting_criteria(posts, scorer)
@@ -58,7 +58,7 @@ def run(
 
     # 3. Build the digest
     if len(threshold_posts) == 0 and len(threshold_boosts) == 0:
-        sys.exit(f"No posts met the threshold for the digest. Exiting.")
+        sys.exit(f"No posts or boost were found for the provided digest arguments. Exiting.")
     else:
         render_digest(
             context={
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         "-f", # for "feed" since t-for-timeline is taken
         default="home",
         dest="timeline",
-        help="The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:list name', 'hashtag:tag'. Defaults to 'home'",
+        help="The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'. Defaults to 'home'",
         required=False,
     )
     arg_parser.add_argument(
@@ -103,10 +103,10 @@ if __name__ == "__main__":
         choices=list(scorers.keys()),
         default="SimpleWeighted",
         dest="scorer",
-        help="""Which post scoring criteria to use.  
-            Simple scorers take a geometric mean of boosts and favs. 
-            Extended scorers include reply counts in the geometric mean. 
-            Weighted scorers multiply the score by an inverse sqaure root 
+        help="""Which post scoring criteria to use.
+            Simple scorers take a geometric mean of boosts and favs.
+            Extended scorers include reply counts in the geometric mean.
+            Weighted scorers multiply the score by an inverse sqaure root
             of the author's followers, to reduce the influence of large accounts.
         """,
     )
@@ -152,6 +152,6 @@ if __name__ == "__main__":
         mastodon_token,
         format_base_url(mastodon_base_url),
         mastodon_username,
-        args.timeline,
+        args.timeline.strip(),
         output_dir,
     )

--- a/run.py
+++ b/run.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         help="""Which post scoring criteria to use.
             Simple scorers take a geometric mean of boosts and favs.
             Extended scorers include reply counts in the geometric mean.
-            Weighted scorers multiply the score by an inverse sqaure root
+            Weighted scorers multiply the score by an inverse square root
             of the author's followers, to reduce the influence of large accounts.
         """,
     )

--- a/run.py
+++ b/run.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         "-f", # for "feed" since t-for-timeline is taken
         default="home",
         dest="timeline",
-        help="The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'. Defaults to 'home'",
+        help="The timeline to summarize: Expects 'home', 'local' or 'federated', or 'list:id', 'hashtag:tag'",
         required=False,
     )
     arg_parser.add_argument(

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta chartset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Mastodon Digest</title>
     {% include "style.html.jinja" %}
@@ -8,17 +9,44 @@
 </head>
 <body>
     <div id="container">
-        <h1>Mastodon Digest</h1>
-        <span id="render-description">Rendered <span id="rendered-value">{{ rendered_at }}</span> from timeline “{{ timeline_name }}” over the past <span id="hours-value">{{ hours }}</span> hours</span><br />
-        <span id="scorer">Scorer: <span id="scorer-value">{{ scorer }}</span></span><br /><span id="threshold">Threshold: <span id="threshold-value">{{ threshold }}</span></span>
-        <h2>Here are some popular posts you may have missed:</h2>
-        {% with posts=posts %}
-            {% include "posts.html.jinja" %}
-        {% endwith %}
-        <h2>Here are some popular boosts you may have missed:</h2>
-        {% with posts=boosts %}
-            {% include "posts.html.jinja" %}
-        {% endwith %}
+        <header>
+            <h1>Mastodon Digest</h1>
+            <p class="render-description">Showing posts {% if boosts %}and boosts{% endif %} from <span class="timeline-name">{{ timeline_name }}</span> timeline</p>
+
+            <details class="render-info">
+                <summary>Digest Render Details</summary>
+                <dl>
+                    <dt>Rendered at</dt>
+                    <dd>{{ rendered_at }}</dd>
+                    <dt>Source timeline</dt>
+                    <dd>{{ timeline_name }}</dd>
+                    <dt>Time period</dt>
+                    <dd>{{ hours }} hours</dd>
+                    <dt>Scorer</dt>
+                    <dd><code>{{ scorer }}</code></dd>
+                    <dt>Threshold</dt>
+                    <dd><code>{{ threshold }}</code></dd>
+                </dl>
+            </details>
+        </header>
+
+        <section class="posts">
+        {% if posts %}
+            <h2>Here are some popular posts you may have missed:</h2>
+            {% with posts=posts %}
+                {% include "posts.html.jinja" %}
+            {% endwith %}
+        {% endif %}
+        </section>
+
+        <section class="posts">
+        {% if boosts %}
+            <h2>Here are some popular boosts you may have missed:</h2>
+            {% with posts=boosts %}
+                {% include "posts.html.jinja" %}
+            {% endwith %}
+        {% endif %}
+        </section>
     </div>
 </body>
 </html>

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -9,7 +9,7 @@
 <body>
     <div id="container">
         <h1>Mastodon Digest</h1>
-        <span id="render-description">Rendered <span id="rendered-value">{{ rendered_at }}</span> from your timeline over the past <span id="hours-value">{{ hours }}</span> hours</span><br />
+        <span id="render-description">Rendered <span id="rendered-value">{{ rendered_at }}</span> from timeline “{{ timeline_name }}” over the past <span id="hours-value">{{ hours }}</span> hours</span><br />
         <span id="scorer">Scorer: <span id="scorer-value">{{ scorer }}</span></span><br /><span id="threshold">Threshold: <span id="threshold-value">{{ threshold }}</span></span>
         <h2>Here are some popular posts you may have missed:</h2>
         {% with posts=posts %}

--- a/templates/style.html.jinja
+++ b/templates/style.html.jinja
@@ -9,7 +9,11 @@
         margin: auto;
         max-width: 640px;
         padding: 10px;
-        text-align: center;
+        margin: 0 auto;
+    }
+
+    .posts {
+        align: center;
     }
 
     div.post {
@@ -36,32 +40,34 @@
         color: white;
     }
 
-    span#render-description {
+    .render-description {
+        margin: 20px 0;
         color: #D3D3D3;
     }
 
-    span#scorer {
+    .render-description .timeline-name {
+        font-weight: bold;
+    }
+
+    .render-info {
         color: #D3D3D3;
+        font-size: 80%;
+        max-width: 640px;
     }
 
-    span#scorer-value {
+    .render-info summary {
+        cursor: pointer;
+    }
+
+    .render-info dl {
+        border: 1px #D3D3D3 solid;
+        border-radius: 10px;
+        padding: 10px;
+    }
+
+    .render-info dt {
         font-weight: bold;
-    }
-
-    span#threshold {
-        color: #D3D3D3;
-    }
-
-    span#threshold-value {
-        font-weight: bold;
-    }
-
-    span#rendered-value {
-        font-weight: bold;
-    }
-
-    span#hours-value {
-        font-weight: bold;
+        margin: 5px 0;
     }
 
     iframe.mastodon-embed {


### PR DESCRIPTION
As someone running a solo personal instance at benward.social, I wanted to use mastodon digest to discover posts from beyond my follow graph, therefore I've added a flag that allows switching to any timeline source supported by the Mastodon.py library:

Use `-f` (for 'feed') flag when running to switch the timeline source for the digest (defaults to 'home').

You can specify:

* `-f local` (local server timeline)
* `-f federated` (public/federated server timeline; useful for people on very small or personal instance servers)
* `-f list:n` (a list, where 'n' is the ID, e.g. `-f list:2`)
* `-f hashtag:tag` (a hashtag, where 'tag' is a hashtag on your server, e.g. `-f hashtag:Introductions`)

For my use case, I run with `-f federated` to get a digest of every posts that's passed through my server; but since I'm the only user, it's a quite interesting summary.

Other changes:

* Since some of these timelines can be lower density, changed the run behaviour to exit with error `1` and a message when no posts are returned from the query, rather than rendering an empty template. This has a side-effect that anyone running the script via cron will maintain their previous, stale digest until new posts meet the threshold.