### PR TITLE
Fix docker error when copying *.py files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN venvs/$NAME/bin/pip install --upgrade pip
 RUN venvs/$NAME/bin/pip install -r requirements.txt
 
 COPY templates/ ./templates/
-COPY *.py .
+COPY *.py ./
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name=$NAME \


### PR DESCRIPTION
When I run `make build` on Ubuntu with Docker 20.10.22 I get this error:

```
Step 16/19 : COPY templates/ ./templates/
 ---> c411350a9cc3
Step 17/19 : COPY *.py .
When using COPY with more than one source file, the destination must be a directory and end with a /
make: *** [Makefile:27: build] Error 1
```

Adding a '/' at the end of the COPY command fixes this error for me.