### PR TITLE
Use dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2==3.1.*
 Mastodon.py==1.8.*
 scipy==1.9.*
+python-dotenv==0.21.*

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import dotenv
 import os
 import sys
 from datetime import datetime
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from scorers import Scorer
     from thresholds import Threshold
 
+dotenv.load_dotenv()
 
 def render_digest(context: dict, output_dir: Path, theme: str = "default") -> None:
     environment = Environment(loader=FileSystemLoader([f"templates/themes/{theme}", "templates/common"]))


### PR DESCRIPTION
It's nice that the docker setup uses .env for environment variables. By adding python-dotenv the standalone Python setup can use it too.
