### PR TITLE
Add user_agent parameter to Mastodon invocation

### DIFF
--- a/run.py
+++ b/run.py
@@ -59,6 +59,7 @@ def run(
     print(f"Building digest from the past {hours} hours...")
 
     mst = Mastodon(
+        user_agent="mastodon_digest",
         access_token=mastodon_token,
         api_base_url=mastodon_base_url,
     )


### PR DESCRIPTION
Fix for #35 - provides a user_agent parameter to the creation of the Mastodon object.